### PR TITLE
添加对Markdown文件的渲染支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ _testmain.go
 *.exe
 *.test
 *.prof
+html2image

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ _cgo_gotypes.go
 _cgo_export.*
 
 _testmain.go
-
+_main.backup.go
 *.exe
 *.test
 *.prof

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ a golang wrapper to reander html, markdown to image
 4. render jpg (markdown only)
 
 [http://127.0.0.1:10000/v1/md2img/to/img.jpg?url=https://github.com/Ink-33/html2image/raw/master/README.md](http://127.0.0.1:10000/v1/md2img/to/img.jpg?url=https://github.com/Ink-33/html2image/raw/master/README.md)
+
 **Notice**: 
 This program will analyze _markdown_ (when `url` end with `.md`). If you don't want to render a _markdown_ file, please add the `nomd=true` parameter to the url.  
 
@@ -27,7 +28,7 @@ This program will analyze _markdown_ (when `url` end with `.md`). If you don't w
 
 1. render image and return json
 
-[http://127.0.0.1:10000/v1/html2img/to/img.json?url=http://www.google.com&format=jpg](http://127.0.0.1:10000/v1/html2img/to/img.json?url=http://www.google.com&format=jpg)
+[http://127.0.0.1:10000/v1/html2img/to/img.json?url=http://www.google.com&format=jpg](http://127.0.0.1:10000/v1/html2img/to/img.json?url=http://www.google.com&format=jpg)  
 
 2. show image url from the json result
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # html2image
-a golang wrapper to reander html to image
+a golang wrapper to reander html, markdown to image
 
 ## Usage
 
@@ -7,32 +7,36 @@ a golang wrapper to reander html to image
 
 1. render png
 
-http://127.0.0.1:8080/to/img.png?url=http://www.google.com
+[http://127.0.0.1:10000/v1/html2img/to/img.png?url=http://www.google.com](http://127.0.0.1:10000/v1/html2img/to/img.png?url=http://www.google.com)
 
 2. render jpg
 
-http://127.0.0.1:8080/to/img.jpg?url=http://www.google.com
+[http://127.0.0.1:10000/v1/html2img/to/img.jpg?url=http://www.google.com](http://127.0.0.1:10000/v1/html2img/to/img.jpg?url=http://www.google.com)
+
+**Notice**: 
+This program will analyze _markdown_ (when `url` end with `.md`). If you don't want to render a _markdown_ file, please add the `nomd=true` parameter to the url.  
 
 ### render image and return image url info
 
 1. render image and return json
 
-http://127.0.0.1:8080/api/v1/to/img.json?url=http://www.google.com&format=jpg
+[http://127.0.0.1:10000/v1/html2img/to/img.json?url=http://www.google.com&format=jpg](http://127.0.0.1:10000/v1/html2img/to/img.json?url=http://www.google.com&format=jpg)
 
 2. show image url from the json result
 
-http://127.0.0.1:8080/show/img/{your image url}
+[http://127.0.0.1:10000/v1/html2img/show/img/](http://127.0.0.1:10000/v1/html2img/show/img/){your image url}
 
 ## More Params In Url
 ```shell
  html: the html content to render, if url has set, this param will ignore
+ md: the markdown content to render, if url has set,
+ this param will ignore (not support yet)
+ nomd: ingore markdown url 
  width: the html page width
  height: the html page height
  quality: the image quality
  
 ```
 
-
-
-
-
+## Changelog
+2020/04/23 Add markdown render support.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ a golang wrapper to reander html, markdown to image
 
 [http://127.0.0.1:10000/v1/html2img/to/img.jpg?url=http://www.google.com](http://127.0.0.1:10000/v1/html2img/to/img.jpg?url=http://www.google.com)
 
+3. render png (markdown only)
+
+[http://127.0.0.1:10000/v1/md2img/to/img.png?url=https://github.com/Ink-33/html2image/raw/master/README.md](http://127.0.0.1:10000/v1/md2img/to/img.png?url=https://github.com/Ink-33/html2image/raw/master/README.md)
+
+4. render jpg (markdown only)
+
+[http://127.0.0.1:10000/v1/md2img/to/img.jpg?url=https://github.com/Ink-33/html2image/raw/master/README.md](http://127.0.0.1:10000/v1/md2img/to/img.jpg?url=https://github.com/Ink-33/html2image/raw/master/README.md)
 **Notice**: 
 This program will analyze _markdown_ (when `url` end with `.md`). If you don't want to render a _markdown_ file, please add the `nomd=true` parameter to the url.  
 

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func (r *ImageRender) BuildImageOptions(req *http.Request, format string) (Image
 	}
 
 	c := ImageOptions{BinaryPath: *r.BinaryPath,
-		Input: url, Html: html, Format: format}
+		Input: url, HTML: html, Format: format}
 
 	width, err := strconv.Atoi(req.Form.Get("width"))
 	if err == nil {
@@ -76,7 +76,7 @@ func (r *ImageRender) RenderBytes(w http.ResponseWriter, req *http.Request, form
 	w.Write(out)
 }
 
-func (r *ImageRender) RenderJson(httpRender *render.Render, w http.ResponseWriter,
+func (r *ImageRender) RenderJSON(httpRender *render.Render, w http.ResponseWriter,
 	req *http.Request, imgRootDir *string) {
 	err := req.ParseForm()
 	if err != nil {
@@ -103,7 +103,7 @@ func (r *ImageRender) RenderJson(httpRender *render.Render, w http.ResponseWrite
 
 	today := time.Now().Format("06/01/02/")
 	os.MkdirAll(*imgRootDir+today, 0755)
-	imgPath := today + contentToMd5(c.Input+c.Html) + "." + format
+	imgPath := today + contentToMd5(c.Input+c.HTML) + "." + format
 	c.Output = *imgRootDir + imgPath
 	log.Println("generate file path:", c.Output)
 	if !checkFileIsExist(c.Output) {
@@ -136,7 +136,7 @@ func contentToMd5(content string) string {
 func main() {
 	binPath := flag.String("path", "/usr/local/bin/wkhtmltoimage", "wkhtmltoimage bin path")
 	imgRootDir := flag.String("img.dir", "./tmp/", "generated image local dir")
-	port := flag.String("web.port", "8080", "web server port")
+	port := flag.String("web.port", "10000", "web server port")
 	flag.Parse()
 	imgRender := ImageRender{}
 	imgRender.BinaryPath = binPath
@@ -144,21 +144,21 @@ func main() {
 	mux := http.NewServeMux()
 	staticHandler := http.FileServer(http.Dir(*imgRootDir))
 
-	mux.HandleFunc("/to/img.png", func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/v1//html2img/to/img.png", func(w http.ResponseWriter, req *http.Request) {
 		imgRender.RenderBytes(w, req, "png")
 	})
-	mux.HandleFunc("/to/img.jpg", func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/v1//html2img/to/img.jpg", func(w http.ResponseWriter, req *http.Request) {
 		imgRender.RenderBytes(w, req, "jpg")
 	})
-	mux.HandleFunc("/show/img/", func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/v1//html2img/show/img/", func(w http.ResponseWriter, req *http.Request) {
 		req.URL.Path = req.URL.Path[9:]
 		staticHandler.ServeHTTP(w, req)
 	})
-	mux.HandleFunc("/api/v1/to/img.json", func(w http.ResponseWriter, req *http.Request) {
-		imgRender.RenderJson(r, w, req, imgRootDir)
+	mux.HandleFunc("/v1//html2img/to/img.json", func(w http.ResponseWriter, req *http.Request) {
+		imgRender.RenderJSON(r, w, req, imgRootDir)
 	})
 	if len(*port) == 0 {
-		*port = "8080"
+		*port = "10000"
 	}
 	http.ListenAndServe(":"+*port, mux)
 }

--- a/wkhtmltoimage.go
+++ b/wkhtmltoimage.go
@@ -20,7 +20,7 @@ type ImageOptions struct {
 	BinaryPath string
 	// Input is the content to turn into an image. REQUIRED
 	//
-	// Can be a url (http://example.com), a local file (/tmp/example.html), or html as a string (send "-" and set the Html value)
+	// Can be a url (http://example.com), a local file (/tmp/example.html), or html as a string (send "-" and set the HTML value)
 	Input string
 	// Format is the type of image to generate
 	//
@@ -46,10 +46,10 @@ type ImageOptions struct {
 	CropW int
 	// Crop-h determines the final image crop height
 	CropH int
-	// Html is a string of html to render into and image.
+	// HTML is a string of html to render into and image.
 	//
 	// Only needed to be set if Input is set to "-"
-	Html string
+	HTML string
 	// Output controls how to save or return the image.
 	//
 	// Leave nil to return a []byte of the image. Set to a path (/tmp/example.png) to save as a file.
@@ -70,8 +70,8 @@ func GenerateImage(options *ImageOptions) ([]byte, error) {
 
 	cmd := exec.Command(options.BinaryPath, arr...)
 
-	if options.Html != "" {
-		cmd.Stdin = strings.NewReader(options.Html)
+	if options.HTML != "" {
+		cmd.Stdin = strings.NewReader(options.HTML)
 	}
 
 	output, err := cmd.CombinedOutput()
@@ -147,7 +147,7 @@ func buildParams(options *ImageOptions) ([]string, error) {
 	// url and output come last
 	if options.Input != "-" {
 		// make sure we dont pass stdin if we aren't expecting it
-		options.Html = ""
+		options.HTML = ""
 	}
 
 	a = append(a, options.Input)


### PR DESCRIPTION
我添加了对Markdown文件的渲染支持；同时，后端在收到请求的时候会打印请求者的IP地址
稍微更改了一些路径与端口，并且已在文档中写出
